### PR TITLE
allowing for multiple A records/wildcard entries

### DIFF
--- a/nsupdate.py
+++ b/nsupdate.py
@@ -118,7 +118,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec = dict(
-            state=dict(required=False, default='present', choices=['present', 'absent'], type='str'),
+            state=dict(required=False, default='present', choices=['present', 'absent', 'multiple'], type='str'),
             server=dict(required=True, type='str'),
             key_name=dict(required=False, type='str'),
             key_secret=dict(required=False, type='str', no_log=True),
@@ -157,10 +157,13 @@ def main():
             if success != True:
                 module.fail_json(msg='Failed to delete DNS record')
             result['changed'] = True
-    elif record.state == 'present':
+    elif record.state == 'present' or record.state == 'multiple':
         if not exists:
             if module.check_mode:
                 module.exit_json(changed=True)
+            success = record.create_record()
+            result['changed'] = True
+        elif exists == 2 and record.state == 'multiple':
             success = record.create_record()
             result['changed'] = True
         elif exists == 2:


### PR DESCRIPTION
Hi there,

Awesome module! Thanks for creating it!

I figured I'd throw this out there.... I had a need to create a wildcard DNS entry (for OpenShift/kubernetes routers) so the same A record pointing to different IPs. Out of the box this module would update the one entry rather than make additional ones.

I added in some logic so I could have my wildcard entries when state is set to 'multiple'. I figured I might as well try and contribute rather than just open an issue :)

What do you think?